### PR TITLE
Issue: 1

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'forum.apps.ForumConfig',
+    'accounts.apps.AccountsConfig',
 ]
 
 MIDDLEWARE = [

--- a/config/settings.py
+++ b/config/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'forum.apps.ForumConfig',
     'accounts.apps.AccountsConfig',
 ]


### PR DESCRIPTION
Issue: 1

The forum and accounts app are added to the settings.py file in config folder for the django-api to work.

Changes: added 'forum.apps.ForumConfig', and 'accounts.apps.AccountsConfig' to the settings.py under Installed_Apps