### PR TITLE
Issue: 33

### DIFF
--- a/forum/serialzers.py
+++ b/forum/serialzers.py
@@ -3,7 +3,7 @@ from forum.models import Question, Answer
 
 class QuestionSerializer(serializers.ModelSerializer):
     #overriding author field to return author's name
-    author = serializers.CharField(source='author.username')
+    author = serializers.CharField(source='author.username', read_only=True)
     
     class Meta:
         model = Question

--- a/forum/views.py
+++ b/forum/views.py
@@ -38,6 +38,28 @@ class QuestionView(viewsets.ModelViewSet):
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         
-        serializer.save(user=request.user)
+        serializer.save(author=request.user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
     
+    def list(self, request):
+        serializer = QuestionSerializer(self.queryset, many=True)
+        return Response(serializer.data)
+    
+    def retrieve(self, request, pk=None):
+        question = get_object_or_404(self.queryset, pk=pk)
+        serializer = QuestionSerializer(question)
+        return Response(serializer.data)
+    
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', True)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        self.perform_update(serializer)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Issue: 27
Short description of what this resolves:
allows get via list, put and patch via update, delete via destroy. 
serializer change->  include the author field in create, put, and patch requests, we need to define it in the QuestionSerializer and set the read_only attribute to False else runs into error.